### PR TITLE
[Feature] JWT 토큰을 이용한 인증 절차

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,5 +42,9 @@ class Config:
     JWT_ALGORITHM = "HS256"
     JWT_EXPRIE_MINUTES = 24 * 60
 
+    # Agent 이름과 비밀번호.
+    AGENT_NAME: str = "agent-01"
+    AGENT_PASSWORD: str = "TYPE_AGENT_PASSWD"
+
 
 config = Config()

--- a/main.py
+++ b/main.py
@@ -20,10 +20,43 @@ from request_to_llm import request_to_llm, validate_model_provider
 from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 
+from passlib.context import CryptContext
+
+
+# 인증시 필요한 변수 생성.
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/v1/agent/auth")
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 class Token(BaseModel):
+    """토큰 발생을 위한 Class.
+
+    Args:
+        BaseModel (_type_): Pydantic의 BaseModel.
+
+    Attributes:
+        access_token (str): 엑세스 토큰.
+        token_type (str): 발행 토큰 종류.
+    """
+
     access_token: str
     token_type: str
+
+
+class Agent(BaseModel):
+    """Agent의 상태를 담기 위한 Class
+
+    Args:
+        BaseModel (_type_): Pydantic의 BaseModel.
+
+    Attributes:
+        agent_name (str): Agent의 이름.
+        is_active (bool): Agent의 활성화 여부.
+        expire_on (datetime): Agent의 만료일.
+    """
+
+    agent_name: str
+    is_active: bool
+    expire_on: datetime
 
 
 def __run_model(args: Namespace, config: Config) -> List:
@@ -108,6 +141,41 @@ def __check_config():
         exit(1)
 
 
+async def get_current_agent(token: Annotated[str, Depends(oauth2_scheme)]) -> Agent:
+    """현재 동작중인 Agent의 상태를 확인하기 위한 함수.
+
+    Args:
+        token (Annotated[str, Depends): 입력받은 JWT 토큰.
+
+    Raises:
+        credentials_exception: 인증 실패시 발생하는 오류.
+
+    Returns:
+        Agent: 인증 성공시 생성된 Agent 정보.
+    """
+
+    # 인증 실패시 출력될 예외 생성.
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        # 입력 받은 JWT 토큰에 대해 decode 시도.
+        payload = jwt.decode(
+            token, config.JWT_SECRET_KEY, algorithms=[config.JWT_ALGORITHM]
+        )
+
+        # Decode 성공 시 정보 가져오기.
+        agent_name: str = payload.get("sub")
+        expire_on: datetime = payload.get("exp")
+    except jwt.InvalidTokenError:
+        # Decode 혹은 정보 취득 실패 시 예외 발생.
+        raise credentials_exception
+
+    return Agent(agent_name=agent_name, is_active=True, expire_on=expire_on)
+
+
 def create_access_token(data: dict, expires_delta: timedelta) -> str:
     """입력받은 데이터와 만료 날짜를 이용하여 JWT 토큰을 발행하는 함수.
 
@@ -188,3 +256,19 @@ def auth(form_data: Annotated[OAuth2PasswordRequestForm, Depends()]) -> Token:
     )
 
     return Token(access_token=access_token, token_type="bearer")
+
+
+@app.get("/v1/agent/status", response_model=Agent)
+async def read_agent_status(
+    current_agent: Annotated[Agent, Depends(get_current_agent)],
+) -> Agent:
+    """사용자 인증을 확인 할 수 있는 API 제공 함수.
+
+    Args:
+        current_agent (Annotated[Agent, Depends): 현재 Agent의 인증 상태.
+
+    Returns:
+        Agent: 현재 Agent의 인증 상태.
+    """
+
+    return current_agent

--- a/main.py
+++ b/main.py
@@ -203,7 +203,9 @@ app = FastAPI()
 
 
 @app.get("/v1/worker/")
-def run(v: Union[str, None]):
+def run(
+    v: Union[str, None], current_agent: Annotated[Agent, Depends(get_current_agent)]
+):
     # TODO: 인자 v를 받아 실제 동작 처리.
     #
     # 동작 실행 전, worker 사용 가능 여부 확인.


### PR DESCRIPTION
# 작업내용
- Worker 생성 공격을 방지하기 위한 인증 방식 추가. 
- `/v1/agent/auth`로 인증 후 인증된 정보를 이용해야 `/v1/worker/`에 접근 가능하도록 조건 추가. 
- `/v1/agent/status`로 Agent의 인증 정보 확인 가능. 
# 사용방법
```python
# API에서 발급할때 사용되는 비밀키, 알고리즘 그리고 사용가능 시간.
JWT_SECRET_KEY = "TYPE_YOUR_SECRET_KEY"
JWT_ALGORITHM = "HS256"
JWT_EXPRIE_MINUTES = 24 * 60

# Agent 이름과 비밀번호.
AGENT_NAME: str = "agent-01"
AGENT_PASSWORD: str = "TYPE_AGENT_PASSWD"
```
1. `config.py`에서 위의 정보를 환경에 맞게 입력 후 `uvicorn main:app --reload`으로 실행. 
2. `http://127.0.0.1:8000/docs`에서 swagger 확인 가능. 
3. 테스트 시 우상단의 `Authorize` 버튼을 이용하여 인증 후 사용. 